### PR TITLE
test(og): de-flake sync unit tests

### DIFF
--- a/pkg/controller/operators/olm/operatorgroup.go
+++ b/pkg/controller/operators/olm/operatorgroup.go
@@ -532,11 +532,12 @@ func (a *Operator) ensureSingletonRBAC(operatorNamespace string, csv *v1alpha1.C
 			}
 			// TODO: this should do something smarter if the cluster role already exists
 			if cr, err := a.opClient.CreateClusterRole(clusterRole); err != nil {
-				// if the CR already exists, but the label is correct, the cache is just behind
-				if k8serrors.IsAlreadyExists(err) && ownerutil.IsOwnedByLabel(cr, csv) {
-					continue
-				} else {
+				if !k8serrors.IsAlreadyExists(err) {
 					return err
+				}
+				// if the CR already exists, but the label is correct, the cache is just behind
+				if cr != nil && ownerutil.IsOwnedByLabel(cr, csv) {
+					continue
 				}
 			}
 			a.logger.Debug("created cluster role")
@@ -572,12 +573,14 @@ func (a *Operator) ensureSingletonRBAC(operatorNamespace string, csv *v1alpha1.C
 			}
 			// TODO: this should do something smarter if the cluster role binding already exists
 			if crb, err := a.opClient.CreateClusterRoleBinding(clusterRoleBinding); err != nil {
-				// if the CR already exists, but the label is correct, the cache is just behind
-				if k8serrors.IsAlreadyExists(err) && ownerutil.IsOwnedByLabel(crb, csv) {
-					continue
-				} else {
+				if !k8serrors.IsAlreadyExists(err) {
 					return err
 				}
+				// if the CRB already exists, but the label is correct, the cache is just behind
+				if crb != nil && ownerutil.IsOwnedByLabel(crb, csv) {
+					continue
+				}
+				return err
 			}
 		}
 	}

--- a/pkg/controller/operators/olm/operatorgroup.go
+++ b/pkg/controller/operators/olm/operatorgroup.go
@@ -532,13 +532,11 @@ func (a *Operator) ensureSingletonRBAC(operatorNamespace string, csv *v1alpha1.C
 			}
 			// TODO: this should do something smarter if the cluster role already exists
 			if cr, err := a.opClient.CreateClusterRole(clusterRole); err != nil {
-				if !k8serrors.IsAlreadyExists(err) {
-					return err
-				}
-				// if the CR already exists, but the label is correct, the cache is just behind
-				if cr != nil && ownerutil.IsOwnedByLabel(cr, csv) {
+				// If the CR already exists, but the label is correct, the cache is just behind
+				if k8serrors.IsAlreadyExists(err) && cr != nil && ownerutil.IsOwnedByLabel(cr, csv) {
 					continue
 				}
+				return err
 			}
 			a.logger.Debug("created cluster role")
 		}
@@ -573,11 +571,8 @@ func (a *Operator) ensureSingletonRBAC(operatorNamespace string, csv *v1alpha1.C
 			}
 			// TODO: this should do something smarter if the cluster role binding already exists
 			if crb, err := a.opClient.CreateClusterRoleBinding(clusterRoleBinding); err != nil {
-				if !k8serrors.IsAlreadyExists(err) {
-					return err
-				}
-				// if the CRB already exists, but the label is correct, the cache is just behind
-				if crb != nil && ownerutil.IsOwnedByLabel(crb, csv) {
+				// If the CRB already exists, but the label is correct, the cache is just behind
+				if k8serrors.IsAlreadyExists(err) && crb != nil && ownerutil.IsOwnedByLabel(crb, csv) {
 					continue
 				}
 				return err


### PR DESCRIPTION
Ended up going down the rabbit hole trying to de-flakeify `TestSyncOperatorGroups` and got something that consistently passes.

There's still _some_ weirdness in the form of a go-routine leak when using a high value for the `-count` test option; on my system the critical value was 32. I suspect this might have to do with an increased number of calls to `wait.Poll*`, but haven't gotten to the bottom of it. However, since nothing major changed in the controllers themselves, I'm confident that this won't cause problems in practice.